### PR TITLE
Add alias template

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
 */
-buildPlugin(useAci: true)
+buildPlugin(useContainerAgent: true)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ mvn clean package
 
 ## Running Locally
 
-Clone this repo, install Java & Maven, and run:
+Clone this repo, install Java & Maven, run this, and open `http://localhost:8080/jenkins/` in your browser.
 ```
     env -i PATH=$PATH mvn hpi:run
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     </issueManagement>
 
     <properties>
-        <revision>1.2.3</revision>
+        <revision>1.2.5</revision>
         <changelist>-SNAPSHOT</changelist>
 
         <pluginName>${project.artifactId}-plugin</pluginName>

--- a/src/main/java/io/jenkins/plugins/opslevel/GlobalConfigUI.java
+++ b/src/main/java/io/jenkins/plugins/opslevel/GlobalConfigUI.java
@@ -43,6 +43,10 @@ public class GlobalConfigUI extends RunListener<Run<?, ?>> implements Describabl
             return globalConfig.run;
         }
 
+        public String getServiceAliasTemplate() {
+            return globalConfig.serviceAliasTemplate;
+        }
+
         public String getWebhookUrl() {
             return globalConfig.webhookUrl;
         }
@@ -74,6 +78,11 @@ public class GlobalConfigUI extends RunListener<Run<?, ?>> implements Describabl
         @DataBoundSetter
         public void setRun(boolean run) {
             globalConfig.run = run;
+        }
+
+        @DataBoundSetter
+        public void setServiceAliasTemplate(String serviceAliasTemplate) {
+            globalConfig.serviceAliasTemplate = cleanupValue(serviceAliasTemplate);
         }
 
         @DataBoundSetter

--- a/src/main/java/io/jenkins/plugins/opslevel/JobListener.java
+++ b/src/main/java/io/jenkins/plugins/opslevel/JobListener.java
@@ -224,10 +224,14 @@ public class JobListener extends RunListener<Run<?, ?>> {
             environment = "Production";
         }
 
-        // Conform to kubernetes conventions with this prefix
+        // Use the serviceAlias if one was supplied in the per-job config. Otherwise, try to use global template.
+        // Otherwise, use the default ${JOB_NAME}
         String serviceAlias = stringSub(opsLevelConfig.serviceAlias, env);
         if (serviceAlias.isEmpty()) {
-            serviceAlias = env.get("JOB_NAME");
+            serviceAlias = stringSub(opsLevelConfig.serviceAliasTemplate, env);
+            if (serviceAlias.isEmpty()) {
+                serviceAlias = env.get("JOB_NAME");
+            }
         }
 
         // Details of who deployed, if available

--- a/src/main/java/io/jenkins/plugins/opslevel/OpsLevelConfig.java
+++ b/src/main/java/io/jenkins/plugins/opslevel/OpsLevelConfig.java
@@ -4,6 +4,7 @@ public class OpsLevelConfig {
     public boolean run;
     public String webhookUrl;
     public String serviceAlias;
+    public String serviceAliasTemplate;
     public String environment;
     public String description;
     public String deployUrl;
@@ -16,6 +17,7 @@ public class OpsLevelConfig {
         run = true;
         webhookUrl = "";
         serviceAlias = "";
+        serviceAliasTemplate = "";
         environment = "";
         description = "";
         deployUrl = "";
@@ -31,6 +33,7 @@ public class OpsLevelConfig {
                "run=" + run +
                ", webhookUrl='" + webhookUrl + '\'' +
                ", serviceAlias='" + serviceAlias + '\'' +
+               ", serviceAliasTemplate='" + serviceAliasTemplate + '\'' +
                ", environment='" + environment + '\'' +
                ", description='" + description + '\'' +
                ", deployUrl='" + deployUrl + '\'' +
@@ -50,6 +53,9 @@ public class OpsLevelConfig {
         }
         if (this.serviceAlias.isEmpty()) {
             this.serviceAlias = otherConfig.serviceAlias;
+        }
+        if (this.serviceAliasTemplate.isEmpty()) {
+            this.serviceAliasTemplate = otherConfig.serviceAliasTemplate;
         }
         if (this.environment.isEmpty()) {
             this.environment = otherConfig.environment;

--- a/src/main/resources/io/jenkins/plugins/opslevel/GlobalConfigUI/global.jelly
+++ b/src/main/resources/io/jenkins/plugins/opslevel/GlobalConfigUI/global.jelly
@@ -18,6 +18,10 @@
       <f:textbox/>
     </f:entry>
 
+    <f:entry title="Service Alias Template" field="serviceAliasTemplate">
+      <f:textbox/>
+    </f:entry>
+
     <f:entry title="Projects to Ignore" field="ignoreList">
       <f:textbox />
     </f:entry>

--- a/src/main/resources/io/jenkins/plugins/opslevel/GlobalConfigUI/help-serviceAliasTemplate.html
+++ b/src/main/resources/io/jenkins/plugins/opslevel/GlobalConfigUI/help-serviceAliasTemplate.html
@@ -1,0 +1,17 @@
+<div>
+  A template string that we will use for each job to create the Service Alias.
+</div>
+<br />
+<div>
+  This field can be overridden at the job level by setting the 'Service Alias'.
+  If neither of these fields are set we will default to ${JOB_NAME}.
+  This will substitute in Environment variables present during the job.
+</div>
+<br />
+<div>
+  For example, if your build process injects a
+  variable called SERVICE_NAME, you could set this field to:
+  <code>
+    ${SERVICE_NAME}
+  </code>
+</div>


### PR DESCRIPTION
This is to allow customers to add a global service alias template. This is for the case where they have an environment variable that describes the service alias across all jobs. Otherwise they would need to set each job's `serviceAlias` to whatever they want, like `${JOB_PREFIX}`. Now they can set it at the global level.