### PR TITLE
Force bump workflow-cps plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
+            <version>2803.v1a_f77ffcc773</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://github.com/advisories/GHSA-mqc2-w9r8-mmxm says it was patched in this version of `workflow-cps`, so just set the version tag to that. Tests still seem to run. There is almost certainly a better way, but I don't know what it is.

(I haven't been able to get the plugin itself to run even on `main`, so.)